### PR TITLE
Changed abbr element value for title

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 	  </header>
 	  <ul class="weekdays">
 	    <li>
-	      <abbr title="S">Sunday</abbr>
+	      <abbr title="Sunday">S</abbr>
 	    </li>
 	    <li>
-	      <abbr title="M">Monday</abbr>
+	      <abbr title="Monday">M</abbr>
 	    </li>
 	    <li>
-	      <abbr title="T">Tuesday</abbr>
+	      <abbr title="Tuesday">T</abbr>
 	    </li>
 	    <li>
-	      <abbr title="W">Wednesday</abbr>
+	      <abbr title="Wednesday">W</abbr>
 	    </li>
 	    <li>
-	      <abbr title="T">Thursday</abbr>
+	      <abbr title="Thursday">T</abbr>
 	    </li>
 	    <li>
-	      <abbr title="F">Friday</abbr>
+	      <abbr title="Friday">F</abbr>
 	    </li>
 	    <li>
-	      <abbr title="S">Saturday</abbr>
+	      <abbr title="Saturday">S</abbr>
 	    </li>
 	  </ul>
 	  <ul class="day-grid">


### PR DESCRIPTION
abbr element is suppose to hold an abbreviation by it's value, and the "entire word or phrase" in it's title, like described here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr